### PR TITLE
T37001 - adding support for Docker's --device parameter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
@@ -1,8 +1,6 @@
 package org.jenkinsci.plugins.nomad;
 
 import hudson.Extension;
-import org.kohsuke.stapler.DataBoundConstructor;
-
 import hudson.Util;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
@@ -10,16 +8,12 @@ import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.labels.LabelAtom;
 import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
 
-import java.lang.reflect.Type;
-import com.google.gson.reflect.TypeToken;
-
-import javax.annotation.Nullable;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import java.util.logging.Logger;
-
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
 
 public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
@@ -46,6 +40,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     private final String prefixCmd;
     private final Boolean forcePull;
     private final String hostVolumes;
+    private final String hostDevices;
     private final String switchUser;
     private final Node.Mode mode;
 
@@ -77,6 +72,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
             String prefixCmd,
             Boolean forcePull,
             String hostVolumes,
+            String hostDevices,
             String switchUser
             ) {
         this.cpu = Integer.parseInt(cpu);
@@ -105,6 +101,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
         this.prefixCmd = prefixCmd;
         this.forcePull = forcePull;
         this.hostVolumes = hostVolumes;
+        this.hostDevices = hostDevices;
         this.switchUser = switchUser;
         readResolve();
     }
@@ -237,6 +234,10 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
     public String getHostVolumes() {
         return hostVolumes;
+    }
+
+    public String getHostDevices() {
+        return hostDevices;
     }
 
     public String getSwitchUser() {

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
@@ -75,6 +75,9 @@
             <f:entry title="Host Volumes" field="hostVolumes">
                 <f:textbox name="hostVolumes" field="hostVolumes" default="" />
             </f:entry>
+            <f:entry title="Host Devices" field="hostDevices">
+                <f:textbox name="hostDevices" field="hostDevices" default="" />
+            </f:entry>
             <f:entry title="Network">
                 <f:textbox name="network" field="network" default="bridge"/>
             </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-hostDevices.html
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-hostDevices.html
@@ -1,0 +1,4 @@
+<div>
+    A comma delimited list of host_path:container_path strings to bind host<br>
+    paths to container paths to specify device mappings.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-hostDevices.html
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-hostDevices.html
@@ -1,4 +1,7 @@
 <div>
-    A comma delimited list of host_path:container_path strings to bind host<br>
-    paths to container paths to specify device mappings.
+    A comma delimited list of mappings of devices for the docker container.<br>
+    Allowed options are:<br>
+    /host_path<br>
+    /host_path:/container_path<br>
+    /host_path:/container_path:permissions<br>
 </div>

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
@@ -4,10 +4,11 @@ import hudson.model.Node;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
-import static org.junit.Assert.assertTrue;
-import java.util.List;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Yegor Andreenko
@@ -20,7 +21,7 @@ public class NomadApiTest {
             "300", "256", "100",
             null, constraintTest, "remoteFs", "3", true, "1", Node.Mode.NORMAL,
             "ams", "0", "image", "dc01", "", "", false, "bridge",
-            "", true, "/mnt:/mnt", "jenkins"
+            "", true, "/mnt:/mnt", "/dev:/dev,/dev,/dev/usb/0:/dev/usb:r", "jenkins"
     );
 
     private NomadCloud nomadCloud = new NomadCloud(
@@ -37,7 +38,7 @@ public class NomadApiTest {
 
     @Test
     public void testStartSlave() {
-        String job = nomadApi.buildSlaveJob("slave-1","secret", slaveTemplate);
+        String job = nomadApi.buildSlaveJob("slave-1", "secret", slaveTemplate);
 
         assertTrue(job.contains("\"Region\":\"ams\""));
         assertTrue(job.contains("\"CPU\":300"));
@@ -48,6 +49,7 @@ public class NomadApiTest {
         assertTrue(job.contains("\"network_mode\":\"bridge\""));
         assertTrue(job.contains("\"force_pull\":true"));
         assertTrue(job.contains("\"volumes\":[\"/mnt:/mnt\"]"));
+        assertTrue(job.contains("\"devices\":[{\"host_path\":\"/dev\",\"container_path\":\"/dev\"},{\"host_path\":\"/dev\"},{\"host_path\":\"/dev/usb/0\",\"cgroup_permissions\":\"r\",\"container_path\":\"/dev/usb\"}]"));
         assertTrue(job.contains("\"User\":\"jenkins\""));
     }
 


### PR DESCRIPTION
we don't want to use --privileged mode because it is not recommended and, more importantly, breaks our testing setup. Therefore, I've added support for docker's --device param to specify only the desired devices for exposing to the container.

Supports all options I'm aware of
--device=/host_path
--device=/host_path:/container_path
--device=/host_path:/container_path:permissions